### PR TITLE
Convert Gradle starter workflows to use `gradle-build-action`

### DIFF
--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -26,12 +26,16 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Gradle
-      run: gradle build
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
 
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
-      run: gradle publish
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: publish
       env:
         USERNAME: ${{ github.actor }}
         TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -26,14 +26,14 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
       with:
         arguments: build
 
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
       with:
         arguments: publish
       env:

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -22,6 +22,6 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
       with:
         arguments: build

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -21,8 +21,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-        cache: gradle
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build


### PR DESCRIPTION
The `gradle-build-action` provides enhanced execution and caching functionality for Gradle. 

Improvements over invoking Gradle directly include:
- Easier to run the workflow with a particular Gradle version
- More sophisticated and more efficient caching of Gradle User Home between invocations
- Detailed reporting of cache usage and cache configuration options
- Automatic capture of Build Scan links